### PR TITLE
Introduce base Spotify configuration

### DIFF
--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -85,10 +85,38 @@
           - docker-compose-plugin
       tags: ['apt', 'docker']
 
-    # configure codium
+    - name: Install Spotify keyring
+      ansible.builtin.get_url:
+        url: "https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg"
+        owner: root
+        group: root
+        mode: "0644"
+        dest: /etc/apt/keyrings/spotify.asc
+      tags: ['keyring', 'spotify']
 
-    # spotify
+    - name: Setup Spotify source
+      ansible.builtin.template:
+        src: templates/spotify-source.j2
+        dest: /etc/apt/sources.list.d/spotify.list
+        owner: root
+        group: root
+        mode: "0644"
+      tags: ['source', 'spotify']
+
+    - name: Install Spotify
+      ansible.builtin.apt:
+        clean: true
+        update_cache: true
+        install_recommends: false
+        name:
+          - spotify-client
+      tags: ['apt', 'spotify']
+
+    # configure codium
+      # key
+      # apt install
+      # extensions
+      # themes
+      # keybindings
 
     # steam
-
-    # - name:

--- a/ansible/templates/spotify-source.j2
+++ b/ansible/templates/spotify-source.j2
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/spotify.asc] http://repository.spotify.com stable non-free

--- a/integration-tests/tag-regressions/expected/003.txt
+++ b/integration-tests/tag-regressions/expected/003.txt
@@ -11,3 +11,4 @@ playbook: ansible/provision.yaml
       Install packages from default repositories	TAGS: [always, apt, install]
       Create keyrings directory	TAGS: [always, apt, keyring]
       Install Docker	TAGS: [apt, docker]
+      Install Spotify	TAGS: [apt, spotify]

--- a/integration-tests/tag-regressions/expected/005.txt
+++ b/integration-tests/tag-regressions/expected/005.txt
@@ -10,3 +10,4 @@ playbook: ansible/provision.yaml
       Install packages from default repositories	TAGS: [always, apt, install]
       Create keyrings directory	TAGS: [always, apt, keyring]
       Install Docker keyring	TAGS: [docker, keyring]
+      Install Spotify keyring	TAGS: [keyring, spotify]

--- a/integration-tests/tag-regressions/expected/006.txt
+++ b/integration-tests/tag-regressions/expected/006.txt
@@ -1,4 +1,4 @@
-Test 001 - # Check the 'default' provisioning order
+Test 006 - # Check spotify installation steps
 
 
 playbook: ansible/provision.yaml
@@ -7,12 +7,8 @@ playbook: ansible/provision.yaml
     tasks:
       Check if 'os_family' is supported	TAGS: [always, os_family]
       Update apt-cache	TAGS: [always, apt, cache]
-      Upgrade default packages	TAGS: [apt, upgrade]
       Install packages from default repositories	TAGS: [always, apt, install]
       Create keyrings directory	TAGS: [always, apt, keyring]
-      Install Docker keyring	TAGS: [docker, keyring]
-      Setup Docker source	TAGS: [docker, source]
-      Install Docker	TAGS: [apt, docker]
       Install Spotify keyring	TAGS: [keyring, spotify]
       Setup Spotify source	TAGS: [source, spotify]
       Install Spotify	TAGS: [apt, spotify]

--- a/integration-tests/tag-regressions/test-tags.sh
+++ b/integration-tests/tag-regressions/test-tags.sh
@@ -71,3 +71,6 @@ run_test "004" "--tags docker" "# Check docker installation steps"
 
 # Test keyrings are configured in the right order.
 run_test "005" "--tags keyring" "# Check keyring installation order"
+
+# Test spotify install execution order.
+run_test "006" "--tags spotify" "# Check spotify installation steps"


### PR DESCRIPTION
Implements provisioning of Spotify keyrings and source lists; installs via `apt`.

Includes test cases to monitor for execution order regressions.